### PR TITLE
Attributes matchers bug fixes

### DIFF
--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -19,9 +19,9 @@ module Jsonapi
         return false unless @target
 
         if @location
-          @target = target.try(:[], :data).try(:[], @location).with_indifferent_access
+          @target = @target.try(:[], :data).try(:[], @location)
         else
-          @target = target.try(:[], :data).with_indifferent_access
+          @target = @target.try(:[], :data)
         end
 
         @value = @target.try(:[], @attribute_name)

--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -10,6 +10,7 @@ module Jsonapi
       end
 
       def with_value(expected_value)
+        @check_value = true
         @expected_value = expected_value
         self
       end
@@ -26,8 +27,7 @@ module Jsonapi
 
         @value = @target.try(:[], @attribute_name)
 
-
-        if @expected_value
+        if @check_value
           if @expected_value.to_s == @value.to_s
             return true
           else
@@ -35,7 +35,7 @@ module Jsonapi
             return false
           end
         else
-          !!@value
+          @target.key?(@attribute_name)
         end
       end
 

--- a/lib/jsonapi/matchers/shared.rb
+++ b/lib/jsonapi/matchers/shared.rb
@@ -4,13 +4,13 @@ module Jsonapi
       def normalize_target(target)
         if target.is_a?(::ActionController::TestResponse)
           begin
-            JSON.parse(target.body)
+            JSON.parse(target.body).with_indifferent_access
           rescue => e
             @failure_message = "Expected response to be json string but was #{target.body.inspect}. #{e.class} - #{e.message}"
             return
           end
         elsif target.is_a?(Hash)
-          return target
+          return target.with_indifferent_access
         else
           @failure_message = "Expected response to be ActionController::TestResponse or hash but was #{target.inspect}"
           return

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -3,7 +3,106 @@ require 'spec_helper'
 describe Jsonapi::Matchers::AttributesIncluded do
   include Jsonapi::Matchers::Attributes
 
-  let(:hash) do
+  shared_examples_for 'attributes included matcher' do
+    describe 'have_attribute' do
+      context 'attribute is included' do
+        it 'matches' do
+          expect(have_attribute(:name).matches?(target)).to be_truthy
+        end
+      end
+
+      context 'attribute is included' do
+        subject { have_attribute(:address) }
+
+        it 'does not match' do
+          expect(subject.matches?(target)).to be_falsey
+        end
+
+        it 'tells you that the target does not contain correct value' do
+          subject.matches?(target)
+          expect(subject.failure_message).to match(/expected attribute 'address' to be included in/)
+        end
+      end
+
+      describe 'with_value' do
+        context 'value exists' do
+          it 'matches' do
+            expect(have_attribute(:name).with_value('cool-name').matches?(target)).to be_truthy
+          end
+        end
+
+        context 'value does not exist' do
+          subject { have_attribute(:name).with_value('bad-name') }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected attribute does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'bad-name' for key 'name', but got 'cool-name'")
+          end
+        end
+
+        context 'attribute does not exist' do
+          subject { have_attribute(:address).with_value('bad-name') }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected attribute does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'bad-name' for key 'address', but got ''")
+          end
+        end
+      end
+    end
+
+    describe 'have_id' do
+      context 'id matches' do
+        it 'matches' do
+          expect(have_id('some-id').matches?(target)).to be_truthy
+        end
+      end
+
+      context 'id does not match' do
+        subject { have_id('wrong-id') }
+
+        it 'does not match' do
+          expect(subject.matches?(target)).to be_falsey
+        end
+
+        it 'tells you the expected attribute does not exist' do
+          subject.matches?(target)
+          expect(subject.failure_message).to eq("expected 'wrong-id' for key 'id', but got 'some-id'")
+        end
+      end
+    end
+
+    describe 'have_type' do
+      context 'type matches' do
+        it 'matches' do
+          expect(have_type('user').matches?(target)).to be_truthy
+        end
+      end
+
+      context 'type does not match' do
+        subject { have_type('car') }
+
+        it 'does not match' do
+          expect(subject.matches?(target)).to be_falsey
+        end
+
+        it 'tells you the expected attribute does not exist' do
+          subject.matches?(target)
+          expect(subject.failure_message).to eq("expected 'car' for key 'type', but got 'user'")
+        end
+      end
+    end
+  end
+
+  let(:json_api_data) do
     {
       data: {
         id: 'some-id',
@@ -16,100 +115,21 @@ describe Jsonapi::Matchers::AttributesIncluded do
     }
   end
 
-  describe 'have_attribute' do
-    context 'attribute is included' do
-      it 'matches' do
-        expect(have_attribute(:name).matches?(hash)).to be_truthy
-      end
-    end
+  context 'target is a hash with symbol keys' do
+    let(:target) { json_api_data }
 
-    context 'attribute is included' do
-      subject { have_attribute(:address) }
-
-      it 'does not match' do
-        expect(subject.matches?(hash)).to be_falsey
-      end
-
-      it 'tells you that the target does not contain correct value' do
-        subject.matches?(hash)
-        expect(subject.failure_message).to match(/expected attribute 'address' to be included in/)
-      end
-    end
-
-    describe 'with_value' do
-      context 'value exists' do
-        it 'matches' do
-          expect(have_attribute(:name).with_value('cool-name').matches?(hash)).to be_truthy
-        end
-      end
-
-      context 'value does not exist' do
-        subject { have_attribute(:name).with_value('bad-name') }
-
-        it 'does not match' do
-          expect(subject.matches?(hash)).to be_falsey
-        end
-
-        it 'tells you the expected attribute does not exist' do
-          subject.matches?(hash)
-          expect(subject.failure_message).to eq("expected 'bad-name' for key 'name', but got 'cool-name'")
-        end
-      end
-
-      context 'attribute does not exist' do
-        subject { have_attribute(:address).with_value('bad-name') }
-
-        it 'does not match' do
-          expect(subject.matches?(hash)).to be_falsey
-        end
-
-        it 'tells you the expected attribute does not exist' do
-          subject.matches?(hash)
-          expect(subject.failure_message).to eq("expected 'bad-name' for key 'address', but got ''")
-        end
-      end
-    end
+    it_should_behave_like 'attributes included matcher'
   end
 
-  describe 'have_id' do
-    context 'id matches' do
-      it 'matches' do
-        expect(have_id('some-id').matches?(hash)).to be_truthy
-      end
-    end
+  context 'target is a hash with string keys' do
+    let(:target) { json_api_data.as_json }
 
-    context 'id does not match' do
-      subject { have_id('wrong-id') }
-
-      it 'does not match' do
-        expect(subject.matches?(hash)).to be_falsey
-      end
-
-      it 'tells you the expected attribute does not exist' do
-        subject.matches?(hash)
-        expect(subject.failure_message).to eq("expected 'wrong-id' for key 'id', but got 'some-id'")
-      end
-    end
+    it_should_behave_like 'attributes included matcher'
   end
 
-  describe 'have_type' do
-    context 'type matches' do
-      it 'matches' do
-        expect(have_type('user').matches?(hash)).to be_truthy
-      end
-    end
+  context 'target is an action controller response' do
+    let(:target) { ActionController::TestResponse.new(json_api_data.to_json) }
 
-    context 'type does not match' do
-      subject { have_type('car') }
-
-      it 'does not match' do
-        expect(subject.matches?(hash)).to be_falsey
-      end
-
-      it 'tells you the expected attribute does not exist' do
-        subject.matches?(hash)
-        expect(subject.failure_message).to eq("expected 'car' for key 'type', but got 'user'")
-      end
-    end
+    it_should_behave_like 'attributes included matcher'
   end
 end

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -11,6 +11,12 @@ describe Jsonapi::Matchers::AttributesIncluded do
         end
       end
 
+      context 'key exists but value is nil' do
+        it 'matches' do
+          expect(have_attribute(:email).matches?(target)).to be_truthy
+        end
+      end
+
       context 'attribute is included' do
         subject { have_attribute(:address) }
 
@@ -41,6 +47,12 @@ describe Jsonapi::Matchers::AttributesIncluded do
           it 'tells you the expected attribute does not exist' do
             subject.matches?(target)
             expect(subject.failure_message).to eq("expected 'bad-name' for key 'name', but got 'cool-name'")
+          end
+        end
+
+        context 'value is explicitly nil' do
+          it 'matches' do
+            expect(have_attribute(:email).with_value(nil).matches?(target)).to be_truthy
           end
         end
 
@@ -110,6 +122,7 @@ describe Jsonapi::Matchers::AttributesIncluded do
         attributes: {
           name: 'cool-name',
           phone_number: '18001111111',
+          email: nil
         }
       }
     }


### PR DESCRIPTION
This p.r. addresses two issues

1. There was a bug on line 23 and 25 of `matchers/attributes_included.rb` where we were checking the wrong `target` variable instead of `@target` and we needed the hash to be "indifferent" BEFORE we checked the `data` attribute.
  * I turned the attributes specs into shared examples to cover all of our bases of different target formats
2. If the attribute we were checking was nil and we wanted it to be nil, it was saying the attribute did not exist.