### PR TITLE
Fixes an error when a test fails using a negated matcher

### DIFF
--- a/lib/jsonapi/matchers/record_included.rb
+++ b/lib/jsonapi/matchers/record_included.rb
@@ -7,6 +7,7 @@ module Jsonapi
         @expected = expected
         @location = location
         @failure_message = nil
+        @failure_message_when_negated = nil
       end
 
       def matches?(target)
@@ -33,6 +34,10 @@ module Jsonapi
 
       def failure_message
         @failure_message || "expected object with an id of '#{@expected.id}' to be included in #{@target.as_json.ai}"
+      end
+
+      def failure_message_when_negated
+        @failure_message_when_negated || "expected object with an id of '#{@expected.id}' to not be included in #{@target.as_json.ai}"
       end
     end
 

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -64,6 +64,7 @@ describe Jsonapi::Matchers::RecordIncluded do
         expect(subject.failure_message).to match(/expected object with an id of 'other_value' to be included in /)
       end
     end
+
   end
 
   context 'checks :data' do
@@ -130,6 +131,29 @@ describe Jsonapi::Matchers::RecordIncluded do
         it 'says the id is not in the response' do
           subject.matches?(response)
           expect(subject.failure_message).to match(/expected object with an id of 'other_value' to be included in /)
+        end
+      end
+
+      context 'handles negated failure cases' do
+        let(:id) { '3' }
+
+        it 'does not blow up' do
+          begin
+            expect(response).to_not have_record(record)
+          rescue NoMethodError => e
+            fail("Should be able to handle negated cases without throwing an error: " + e.to_s)
+          rescue RSpec::Expectations::ExpectationNotMetError
+          end
+        end
+
+        it 'shows a negated error message' do
+          @failure = nil
+          begin
+            expect(response).to_not have_record(record)
+          rescue RSpec::Expectations::ExpectationNotMetError => e
+            @failure = e.message
+          end
+          expect(@failure).to match(/expected object with an id of '3' to not be included in /)
         end
       end
     end


### PR DESCRIPTION
This fixes an unhandled exception when a test fails using a negated matcher. As an example if we had a record with `id=3` and said `expect(response).to_not have_record(record)` but the record existed, the test would fail and thrown an unhandled exception due to a missing negated message handler. 