### PR TITLE
supports rails 5 versions of active support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ end
 ```
 
 
-#### Supports ActionController::TestResponse and Hash
+#### Supports ActionDispatch::TestResponse, ActionController::TestResponse, and Hash
 
 ```
 expect(response).to have_id(book.id)

--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", "~> 4.0"
+  spec.add_dependency "activesupport", ">= 4.0", "< 6"
   spec.add_dependency "awesome_print"
 
   spec.add_development_dependency "bundler", "~> 1.12"

--- a/lib/jsonapi/matchers/shared.rb
+++ b/lib/jsonapi/matchers/shared.rb
@@ -2,7 +2,7 @@ module Jsonapi
   module Matchers
     module Shared
       def normalize_target(target)
-        if target.is_a?(::ActionController::TestResponse)
+        if test_response?(target)
           begin
             JSON.parse(target.body).with_indifferent_access
           rescue => e
@@ -12,9 +12,16 @@ module Jsonapi
         elsif target.is_a?(Hash)
           return target.with_indifferent_access
         else
-          @failure_message = "Expected response to be ActionController::TestResponse or hash but was #{target.inspect}"
+          @failure_message = "Expected response to be ActionDispatch::TestResponse, ActionController::TestResponse, or hash but was #{target.inspect}"
           return
         end
+      end
+
+      private
+
+      def test_response?(target)
+        defined?(::ActionDispatch::TestResponse) && target.is_a?(::ActionDispatch::TestResponse) ||
+          defined?(::ActionController::TestResponse) && target.is_a?(::ActionController::TestResponse)
       end
     end
   end

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -141,7 +141,7 @@ describe Jsonapi::Matchers::AttributesIncluded do
   end
 
   context 'target is an action controller response' do
-    let(:target) { ActionController::TestResponse.new(json_api_data.to_json) }
+    let(:target) { ActionDispatch::TestResponse.new(json_api_data.to_json) }
 
     it_should_behave_like 'attributes included matcher'
   end

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -14,14 +14,14 @@ describe Jsonapi::Matchers::RecordIncluded do
       subject.matches?(response)
     end
 
-    it 'tells you that the response is not an ActionController::TestResponse' do
-      expect(subject.failure_message).to eq("Expected response to be ActionController::TestResponse or hash but was \"\"")
+    it 'tells you that the response is not an ActionDispatch::TestResponse' do
+      expect(subject.failure_message).to eq("Expected response to be ActionDispatch::TestResponse, ActionController::TestResponse, or hash but was \"\"")
     end
   end
 
   context 'expected is not a json body' do
     let(:subject) { have_record(record) }
-    let(:response) { ActionController::TestResponse.new(response_data.to_json) }
+    let(:response) { ActionDispatch::TestResponse.new(response_data.to_json) }
     let(:response_data) { nil }
 
     before do
@@ -35,7 +35,7 @@ describe Jsonapi::Matchers::RecordIncluded do
 
   context 'checks :included' do
     let(:subject) { include_record(record) }
-    let(:response) { ActionController::TestResponse.new(response_data.to_json) }
+    let(:response) { ActionDispatch::TestResponse.new(response_data.to_json) }
     let(:response_data) do
       {
         included: [{
@@ -69,7 +69,7 @@ describe Jsonapi::Matchers::RecordIncluded do
 
   context 'checks :data' do
     let(:subject) { have_record(record) }
-    let(:response) { ActionController::TestResponse.new(response_data.to_json) }
+    let(:response) { ActionDispatch::TestResponse.new(response_data.to_json) }
 
     context 'data is an array' do
       let(:response_data) do

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -29,7 +29,7 @@ describe Jsonapi::Matchers::RecordIncluded do
     end
 
     it 'tells you that the response body is not json' do
-      expect(subject.failure_message).to eq("Expected response to be json string but was \"null\". JSON::ParserError - 757: unexpected token at 'null'")
+      expect(subject.failure_message).to match("Expected response to be json string but was \"null\". JSON::ParserError - 776: unexpected token at 'null'")
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'jsonapi/matchers'
 require 'pry'
 
 
-module ActionController
+module ActionDispatch
   class TestResponse
     attr_accessor :body
 


### PR DESCRIPTION
Adds rails 5 support.

- Updates active support versions that are supported
- Updates parse error code in spec for newer ruby versions
- handles ActionDispatch::TestResponse which is what is now used in rails 5 controller tests

Tested using mock rails 5 app. confirmed it works in current ppsuite build(https://github.com/PopularPays/PPSuite/pull/4319)