### PR TITLE
Have relationship helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ expect(response).to have_relationship('relationship_name')
 ```
 
 ```ruby
+expect(response).to have_relationship('relationship_name').with_value({'data' => nil})
+```
+
+```ruby
 RSpec.describe BooksController do
   include Jsonapi::Matchers::Attributes
 
@@ -123,6 +127,10 @@ RSpec.describe BooksController do
 
   it "includes the relationship attribute" do
     expect(response).to have_relationship('author')
+  end
+
+  it "includes the relationship value" do
+    expect(response).to have_relationship('house').with_value({'data' => nil})
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ expect(response).to have_attribute('attribute_name').with_value('attribute_value
 ```
 
 ```ruby
+expect(response).to have_relationship('relationship_name')
+```
+
+```ruby
 RSpec.describe BooksController do
   include Jsonapi::Matchers::Attributes
 
@@ -115,6 +119,10 @@ RSpec.describe BooksController do
 
   it "includes the correct attribute value" do
     expect(response).to have_attribute('name').with_value('Moby Dick')
+  end
+
+  it "includes the relationship attribute" do
+    expect(response).to have_relationship('author')
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ expect(response).to have_relationship('relationship_name').with_value({'data' =>
 ```
 
 ```ruby
+expect(response).to have_relationship('relationship_name').with_record(record)
+```
+
+```ruby
 RSpec.describe BooksController do
   include Jsonapi::Matchers::Attributes
 
@@ -131,6 +135,10 @@ RSpec.describe BooksController do
 
   it "includes the relationship value" do
     expect(response).to have_relationship('house').with_value({'data' => nil})
+  end
+
+  it "includes the relationship record" do
+    expect(response).to have_relationship('author').with_record(author)
   end
 end
 ```

--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -34,28 +34,9 @@ module Jsonapi
         @value = @target.try(:[], @attribute_name)
 
         if @check_value
-          if @expected_value.to_s == @value.to_s
-            return true
-          else
-            @failure_message = "expected '#{@expected_value}' for key '#{@attribute_name}', but got '#{@value}'"
-            return false
-          end
+          value_exists?
         elsif @check_record
-          data = @value.try(:[], 'data')
-
-          if data.is_a?(Array)
-            if data.map{|d| d['id']}.include?(@expected_record_id)
-              return true
-            else
-              @failure_message = "expected '#{@expected_record_id}' to be the an id in relationship '#{@attribute_name}', but got '#{@value['data']}'"
-              return false
-            end
-          elsif @expected_record_id == @value.try(:[], 'data').try(:[], 'id')
-            return true
-          else
-            @failure_message = "expected '#{@expected_record_id}' to be the id for relationship '#{@attribute_name}', but got '#{@value}'"
-            return false
-          end
+          record_exists?
         else
           @target.key?(@attribute_name)
         end
@@ -63,6 +44,35 @@ module Jsonapi
 
       def failure_message
         @failure_message || "expected attribute '#{@attribute_name}' to be included in #{@target.as_json.ai}"
+      end
+
+      private
+
+      def value_exists?
+        if @expected_value.to_s == @value.to_s
+          true
+        else
+          @failure_message = "expected '#{@expected_value}' for key '#{@attribute_name}', but got '#{@value}'"
+          false
+        end
+      end
+
+      def record_exists?
+        data = @value.try(:[], 'data')
+
+        if data.is_a?(Array)
+          if data.map{|d| d['id']}.include?(@expected_record_id)
+            return true
+          else
+            @failure_message = "expected '#{@expected_record_id}' to be the an id in relationship '#{@attribute_name}', but got '#{@value['data']}'"
+            return false
+          end
+        elsif @expected_record_id == @value.try(:[], 'data').try(:[], 'id')
+          return true
+        else
+          @failure_message = "expected '#{@expected_record_id}' to be the id for relationship '#{@attribute_name}', but got '#{@value}'"
+          return false
+        end
       end
     end
 

--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -64,7 +64,7 @@ module Jsonapi
           if data.map{|d| d['id']}.include?(@expected_record_id)
             return true
           else
-            @failure_message = "expected '#{@expected_record_id}' to be the an id in relationship '#{@attribute_name}', but got '#{@value['data']}'"
+            @failure_message = "expected '#{@expected_record_id}' to be an id in relationship '#{@attribute_name}', but got '#{@value['data']}'"
             return false
           end
         elsif @expected_record_id == @value.try(:[], 'data').try(:[], 'id')

--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -56,6 +56,10 @@ module Jsonapi
       def have_attribute(attribute_name)
         AttributesIncluded.new(attribute_name, :attributes)
       end
+
+      def have_relationship(relationship_name)
+        AttributesIncluded.new(relationship_name, :relationships)
+      end
     end
   end
 end

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -236,7 +236,7 @@ describe Jsonapi::Matchers::AttributesIncluded do
 
           it 'tells you the relationship does not exist' do
             subject.matches?(target)
-            expect(subject.failure_message).to match("expected 'some-chair-id-3' to be the an id in relationship 'chairs', but got")
+            expect(subject.failure_message).to match("expected 'some-chair-id-3' to be an id in relationship 'chairs', but got")
           end
         end
 

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -112,6 +112,27 @@ describe Jsonapi::Matchers::AttributesIncluded do
         end
       end
     end
+
+    describe 'have_relationship' do
+      context 'relationship matches' do
+        it 'matches' do
+          expect(have_relationship('car').matches?(target)).to be_truthy
+        end
+      end
+
+      context 'relationship does not match' do
+        subject { have_relationship('monster_truck') }
+
+        it 'does not match' do
+          expect(subject.matches?(target)).to be_falsey
+        end
+
+        it 'tells you the expected attribute does not exist' do
+          subject.matches?(target)
+          expect(subject.failure_message).to match(/expected attribute 'monster_truck' to be included in/)
+        end
+      end
+    end
   end
 
   let(:json_api_data) do
@@ -123,6 +144,11 @@ describe Jsonapi::Matchers::AttributesIncluded do
           name: 'cool-name',
           phone_number: '18001111111',
           email: nil
+        },
+        relationships: {
+          car: {
+            data: { type: 'cars', id: 'some-car-id' }
+          }
         }
       }
     }

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -192,6 +192,99 @@ describe Jsonapi::Matchers::AttributesIncluded do
           end
         end
       end
+
+      describe 'with_record' do
+        context 'record exists' do
+          let(:record) { OpenStruct.new(id: 'some-car-id') }
+
+          it 'matches' do
+            expect(have_relationship(:car).with_record(record).matches?(target)).to be_truthy
+          end
+        end
+
+        context 'record id does not match' do
+          let(:record) { OpenStruct.new(id: 'not-the-right-car-id') }
+
+          subject { have_relationship(:car).with_record(record) }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected id does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'not-the-right-car-id' to be the id for relationship 'car', but got '{\"data\"=>{\"type\"=>\"cars\", \"id\"=>\"some-car-id\"}}'")
+          end
+        end
+
+        context 'relationship is array and it matches' do
+          let(:record) { OpenStruct.new(id: 'some-chair-id-1') }
+
+          it 'matches' do
+            expect(have_relationship(:chairs).with_record(record).matches?(target)).to be_truthy
+          end
+        end
+
+        context 'relationship is array and it does not match' do
+          let(:record) { OpenStruct.new(id: 'some-chair-id-3') }
+
+          subject { have_relationship(:chairs).with_record(record) }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the relationship does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to match("expected 'some-chair-id-3' to be the an id in relationship 'chairs', but got")
+          end
+        end
+
+        context 'relationship does not have an id attribute' do
+          let(:record) { OpenStruct.new(id: 'some-chair-id-1') }
+
+          subject { have_relationship(:house).with_record(record) }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected attribute does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'some-chair-id-1' to be the id for relationship 'house', but got '{\"data\"=>nil}'")
+          end
+        end
+
+        context 'relationship is nil' do
+          let(:record) { OpenStruct.new(id: 'some-chair-id-1') }
+
+          subject { have_relationship(:plane).with_record(record) }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected relationship does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'some-chair-id-1' to be the id for relationship 'plane', but got ''")
+          end
+        end
+
+        context 'relationship does not exist' do
+          let(:record) { OpenStruct.new(id: 'some-chair-id-1') }
+
+          subject { have_relationship(:does_not_exist).with_record(record) }
+
+          it 'does not match' do
+            expect(subject.matches?(target)).to be_falsey
+          end
+
+          it 'tells you the expected relationship does not exist' do
+            subject.matches?(target)
+            expect(subject.failure_message).to eq("expected 'some-chair-id-1' to be the id for relationship 'does_not_exist', but got ''")
+          end
+        end
+      end
     end
   end
 
@@ -212,7 +305,13 @@ describe Jsonapi::Matchers::AttributesIncluded do
           house: {
             data: nil
           },
-          plane: nil
+          plane: nil,
+          chairs: {
+            data: [
+              { type: 'chairs', id: 'some-chair-id-1' },
+              { type: 'chairs', id: 'some-chair-id-2' }
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
Resolves: https://github.com/PopularPays/jsonapi-matchers/issues/12.

Please check out ReadMe changes to see what this does!

As a side note: I don't love how we have separate includes for

```
include Jsonapi::Matchers::Attributes
include Jsonapi::Matchers::Record
```

as the lines are becoming blurred now that we check records in the attributes helper. I think that should be a separate p.r., however.