### PR TITLE
Handle the case where the expected record's id is not a string.

### DIFF
--- a/lib/jsonapi/matchers/record_included.rb
+++ b/lib/jsonapi/matchers/record_included.rb
@@ -23,9 +23,9 @@ module Jsonapi
 
         case target_location
         when Array
-          return target_location.any?{|t| t.with_indifferent_access["id"] == @expected.id}
+          return target_location.any?{ |t| t.with_indifferent_access["id"] == @expected.id.to_s }
         when ::Hash
-          return target_location.with_indifferent_access["id"] == @expected.id
+          return target_location.with_indifferent_access["id"] == @expected.id.to_s
         else
           @failure_message = "Expected value of #{@location} to be an Array or Hash but was #{target.inspect}"
           return false

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -64,7 +64,6 @@ describe Jsonapi::Matchers::RecordIncluded do
         expect(subject.failure_message).to match(/expected object with an id of 'other_value' to be included in /)
       end
     end
-
   end
 
   context 'checks :data' do
@@ -85,6 +84,14 @@ describe Jsonapi::Matchers::RecordIncluded do
 
         it 'matches' do
           expect(subject.matches?(response)).to eq true
+        end
+
+        context 'the record id is not a string' do
+          let(:id) { 3 }
+
+          it 'matches' do
+            expect(subject.matches?(response)).to eq true
+          end
         end
       end
 
@@ -118,6 +125,14 @@ describe Jsonapi::Matchers::RecordIncluded do
 
         it 'matches' do
           expect(subject.matches?(response)).to eq true
+        end
+
+        context 'the record id is not a string' do
+          let(:id) { 3 }
+
+          it 'matches' do
+            expect(subject.matches?(response)).to eq true
+          end
         end
       end
 


### PR DESCRIPTION
Our codebase uses `Integer` ids so we were getting spec failures while using `#have_record`. It was trying to compare a string to an integer and failing. To resolve this issue I coerced `expected_record.id` to a string with `#to_s`. This should be find for all string id values (like uuids) and also integer id values.

See specs for an example of the issue.