### PR TITLE
Add matcher descriptions

### DIFF
--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -3,10 +3,13 @@ module Jsonapi
     class AttributesIncluded
       include Jsonapi::Matchers::Shared
 
-      def initialize(attribute_name, location)
+      attr_reader :description
+
+      def initialize(attribute_name, location, description)
         @attribute_name = attribute_name
         @location = location
         @failure_message = nil
+        @description = description
       end
 
       def with_value(expected_value)
@@ -78,19 +81,19 @@ module Jsonapi
 
     module Attributes
       def have_id(id)
-        AttributesIncluded.new('id', nil).with_value(id)
+        AttributesIncluded.new('id', nil, "have id: #{id}").with_value(id)
       end
 
       def have_type(type)
-        AttributesIncluded.new('type', nil).with_value(type)
+        AttributesIncluded.new('type', nil, "have type: #{type}").with_value(type)
       end
 
       def have_attribute(attribute_name)
-        AttributesIncluded.new(attribute_name, :attributes)
+        AttributesIncluded.new(attribute_name, :attributes, "have attribute: #{attribute_name}")
       end
 
       def have_relationship(relationship_name)
-        AttributesIncluded.new(relationship_name, :relationships)
+        AttributesIncluded.new(relationship_name, :relationships, "have relationship: #{relationship_name}")
       end
     end
   end

--- a/lib/jsonapi/matchers/record_included.rb
+++ b/lib/jsonapi/matchers/record_included.rb
@@ -3,11 +3,14 @@ module Jsonapi
     class RecordIncluded
       include Jsonapi::Matchers::Shared
 
-      def initialize(expected, location)
+      attr_reader :description
+
+      def initialize(expected, location, description)
         @expected = expected
         @location = location
         @failure_message = nil
         @failure_message_when_negated = nil
+        @description = description
       end
 
       def matches?(target)
@@ -43,11 +46,11 @@ module Jsonapi
 
     module Record
       def have_record(expected)
-        RecordIncluded.new(expected, 'data')
+        RecordIncluded.new(expected, 'data', 'have record')
       end
 
       def include_record(expected)
-        RecordIncluded.new(expected, 'included')
+        RecordIncluded.new(expected, 'included', 'include record')
       end
     end
   end

--- a/lib/jsonapi/matchers/shared.rb
+++ b/lib/jsonapi/matchers/shared.rb
@@ -4,7 +4,8 @@ module Jsonapi
       def normalize_target(target)
         if test_response?(target)
           begin
-            JSON.parse(target.body).with_indifferent_access
+            parsed_body = JSON.parse(target.body)
+            parsed_body.with_indifferent_access
           rescue => e
             @failure_message = "Expected response to be json string but was #{target.body.inspect}. #{e.class} - #{e.message}"
             return

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -3,8 +3,16 @@ require 'spec_helper'
 describe Jsonapi::Matchers::AttributesIncluded do
   include Jsonapi::Matchers::Attributes
 
+  it 'sets the description correctly' do
+    expect(described_class.new('foo', 'bar', 'matcher description').description).to eq('matcher description')
+  end
+
   shared_examples_for 'attributes included matcher' do
     describe 'have_attribute' do
+      it 'has the correct description' do
+        expect(have_attribute('some-attr').description).to eq("have attribute: some-attr")
+      end
+
       context 'attribute is included' do
         it 'matches' do
           expect(have_attribute(:name).matches?(target)).to be_truthy
@@ -72,6 +80,10 @@ describe Jsonapi::Matchers::AttributesIncluded do
     end
 
     describe 'have_id' do
+      it 'has the correct description' do
+        expect(have_id('some-id').description).to eq("have id: some-id")
+      end
+
       context 'id matches' do
         it 'matches' do
           expect(have_id('some-id').matches?(target)).to be_truthy
@@ -93,6 +105,10 @@ describe Jsonapi::Matchers::AttributesIncluded do
     end
 
     describe 'have_type' do
+      it 'has the correct description' do
+        expect(have_type('some-type').description).to eq("have type: some-type")
+      end
+
       context 'type matches' do
         it 'matches' do
           expect(have_type('user').matches?(target)).to be_truthy
@@ -114,6 +130,10 @@ describe Jsonapi::Matchers::AttributesIncluded do
     end
 
     describe 'have_relationship' do
+      it 'has the correct description' do
+        expect(have_relationship('some-relationship').description).to eq("have relationship: some-relationship")
+      end
+
       context 'relationship is included' do
         it 'matches' do
           expect(have_relationship(:car).matches?(target)).to be_truthy

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -6,6 +6,10 @@ describe Jsonapi::Matchers::RecordIncluded do
   let(:id) { }
   let(:record) { double(:record, {id: id}) }
 
+  it 'sets the description correctly' do
+    expect(described_class.new('foo', 'data', 'matcher description').description).to eq('matcher description')
+  end
+
   context 'expected is not a request object' do
     let(:subject) { have_record(record) }
     let(:response) { String.new }

--- a/spec/jsonapi/record_included_spec.rb
+++ b/spec/jsonapi/record_included_spec.rb
@@ -21,15 +21,15 @@ describe Jsonapi::Matchers::RecordIncluded do
 
   context 'expected is not a json body' do
     let(:subject) { have_record(record) }
-    let(:response) { ActionDispatch::TestResponse.new(response_data.to_json) }
-    let(:response_data) { nil }
+    let(:response) { ActionDispatch::TestResponse.new(response_data) }
+    let(:response_data) { '{' }
 
     before do
       subject.matches?(response)
     end
 
     it 'tells you that the response body is not json' do
-      expect(subject.failure_message).to match("Expected response to be json string but was \"null\". JSON::ParserError - 776: unexpected token at 'null'")
+      expect(subject.failure_message).to match("Expected response to be json string but was \"{\". JSON::ParserError - 765: unexpected token at '{'")
     end
   end
 


### PR DESCRIPTION
This is required by RSpec to use the one-liner syntax. If the matcher doesn't have a description you get a multiline message in your test output. 🤢 

>    When using RSpec's one-liner syntax (e.g. `it { is_expected.to matcher }`), the description is used to generate the example's doc string since you have not provided one.

Source: https://github.com/rspec/rspec-expectations/blob/master/lib/rspec/matchers/matcher_protocol.rb#L42-L53

I went with simple descriptions for the most part. There is also one change to a different test because `JSON.parse` in the test set up was no longer failing for me locally.