### PR TITLE
Update included resources example in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ RSpec.describe BooksController do
   let!(:book2) { create(:book, author: author) }
 
   before do
-    get :index
+    get :index, include: ['authors']
   end
 
   it "includes the author" do


### PR DESCRIPTION
The example was checking for included resources, but the request used in the example didn't have the `include` param set.