### PR TITLE
Add #failure_message_when_negated for the Jsonapi::Matchers::AttributesIncluded matchers.

### DIFF
--- a/lib/jsonapi/matchers/attributes_included.rb
+++ b/lib/jsonapi/matchers/attributes_included.rb
@@ -9,6 +9,7 @@ module Jsonapi
         @attribute_name = attribute_name
         @location = location
         @failure_message = nil
+        @failure_message_when_negated = nil
         @description = description
       end
 
@@ -49,10 +50,15 @@ module Jsonapi
         @failure_message || "expected attribute '#{@attribute_name}' to be included in #{@target.as_json.ai}"
       end
 
+      def failure_message_when_negated
+        @failure_message_when_negated || "expected attribute '#{@attribute_name}' not to be included in #{@target.as_json.ai}"
+      end
+
       private
 
       def value_exists?
         if @expected_value.to_s == @value.to_s
+          @failure_message_when_negated = "expected key '#{@attribute_name}' to not be '#{@expected_value}', but it was '#{@value}'"
           true
         else
           @failure_message = "expected '#{@expected_value}' for key '#{@attribute_name}', but got '#{@value}'"
@@ -65,12 +71,14 @@ module Jsonapi
 
         if data.is_a?(Array)
           if data.map{|d| d['id']}.include?(@expected_record_id)
+            @failure_message_when_negated = "expected '#{@attribute_name}' not to contain the id '#{@expected_record_id}', but got '#{@value['data']}'"
             return true
           else
             @failure_message = "expected '#{@expected_record_id}' to be an id in relationship '#{@attribute_name}', but got '#{@value['data']}'"
             return false
           end
         elsif @expected_record_id == @value.try(:[], 'data').try(:[], 'id')
+          @failure_message_when_negated = "expected '#{@expected_record_id}' not to be the id for relationship '#{@attribute_name}', but got '#{@value}'"
           return true
         else
           @failure_message = "expected '#{@expected_record_id}' to be the id for relationship '#{@attribute_name}', but got '#{@value}'"

--- a/spec/jsonapi/attributes_included_spec.rb
+++ b/spec/jsonapi/attributes_included_spec.rb
@@ -38,6 +38,15 @@ describe Jsonapi::Matchers::AttributesIncluded do
         end
       end
 
+      context 'matcher is negated and attribute is included' do
+        subject { have_attribute(:name) }
+
+        it 'tells you that the target should not contain the correct value but does' do
+          subject.matches?(target)
+          expect(subject.failure_message_when_negated).to match(/expected attribute 'name' not to be included in/)
+        end
+      end
+
       describe 'with_value' do
         context 'value exists' do
           it 'matches' do
@@ -55,6 +64,15 @@ describe Jsonapi::Matchers::AttributesIncluded do
           it 'tells you the expected attribute does not exist' do
             subject.matches?(target)
             expect(subject.failure_message).to eq("expected 'bad-name' for key 'name', but got 'cool-name'")
+          end
+        end
+
+        context 'matcher is negated and value exists' do
+          subject { have_attribute(:name).with_value('cool-name') }
+
+          it 'tells you that the target should not contain the correct value but does' do
+            subject.matches?(target)
+            expect(subject.failure_message_when_negated).to match(/expected key 'name' to not be 'cool-name', but it was 'cool-name'/)
           end
         end
 
@@ -88,6 +106,14 @@ describe Jsonapi::Matchers::AttributesIncluded do
         it 'matches' do
           expect(have_id('some-id').matches?(target)).to be_truthy
         end
+
+        it 'has the expected negated failure message' do
+          matcher = have_id('some-id')
+
+          matcher.matches?(target)
+
+          expect(matcher.failure_message_when_negated).to match(/expected key 'id' to not be 'some-id', but it was 'some-id'/)
+        end
       end
 
       context 'id does not match' do
@@ -113,6 +139,14 @@ describe Jsonapi::Matchers::AttributesIncluded do
         it 'matches' do
           expect(have_type('user').matches?(target)).to be_truthy
         end
+
+        it 'has the expected negated failure message' do
+          matcher = have_type('user')
+
+          matcher.matches?(target)
+
+          expect(matcher.failure_message_when_negated).to match(/expected key 'type' to not be 'user', but it was 'user'/)
+        end
       end
 
       context 'type does not match' do
@@ -137,6 +171,14 @@ describe Jsonapi::Matchers::AttributesIncluded do
       context 'relationship is included' do
         it 'matches' do
           expect(have_relationship(:car).matches?(target)).to be_truthy
+        end
+
+        it 'has the expected negated failure message' do
+          matcher = have_relationship('some-relationship')
+
+          matcher.matches?(target)
+
+          expect(matcher.failure_message_when_negated).to match(/expected attribute 'some-relationship' not to be included in/)
         end
       end
 
@@ -167,6 +209,14 @@ describe Jsonapi::Matchers::AttributesIncluded do
 
           it 'matches' do
             expect(have_relationship(:car).with_value(relationship_value).matches?(target)).to be_truthy
+          end
+
+          it 'has the expected negated failure message' do
+            matcher = have_relationship(:car).with_value(relationship_value)
+
+            matcher.matches?(target)
+
+            expect(matcher.failure_message_when_negated).to match(/expected key 'car' to not be '.*', but it was '.*'/)
           end
         end
 


### PR DESCRIPTION
Without this RSpec will raise an error when the matcher is negated and returns a falsy value.

At Chowly we were implementing sparse field sets and needed to test that attributes and relationships that aren't included in the response. Everything was fine when the tests were passing but when one of the `expect(subject).not_to have_id/type/attribute/relationship(value)` assertions failed we hit a method not found error. This message was already set in the `Jsonapi::Matchers::RecordIncluded` class.