### PR TITLE
Add versioning

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,26 @@
+# Releasing
+
+_NB: Currently this gem is not published to RubyGems._
+
+To make managing the version of this gem easier we are using the
+[bump](https://github.com/gregorym/bump) gem. Please review the following
+information to understand how to update the version of this gem as changes
+are made.
+
+## How to update the version
+
+To update the version and create a tag use the following command:
+
+```
+bump <major/minor/patch/pre> --tag --tag-prefix v --commit-message "<your commit message>"
+git push origin --tags
+```
+
+If you want to provide a multi line commit message you can use:
+
+_NB: You will have to add the tag manually._
+```
+bump <major/minor/patch/pre> --no-commit
+git tag v<version>
+git push origin --tags
+```

--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.0", "< 6"
   spec.add_dependency "awesome_print"
 
+  spec.add_development_dependency "bump", "~> 0.9.0"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Here is my proposal for a first pass at adding tagged versions to this gem. Having a tag to point at always feels a bit better to me than just pointing at the main branch of the repo and needing to check the lock file to see which SHA my project is using.

So far I was trying to keep the process lightweight, but am open to feedback if we want something more robust.

Once this PR is accepted my plan is to use these steps to publish `v1.0.0`. It won't be a breaking change, but 1.0.0 feels better than 0.2.0 since we are moving from the pre-versioning era to the versioned era. 


