### PR TITLE
Update gemspec to allow for ActiveSupport versions below 7.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,13 +20,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
+        bundler: 2.1.4
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activesupport", ">= 4.0", "< 6.1"
+  spec.add_dependency "activesupport", ">= 4.0", "< 7"
   spec.add_dependency "awesome_print"
 
   spec.add_development_dependency "bump", "~> 0.9.0"


### PR DESCRIPTION
My team is upgrading our project to Rails `6.1.4.1` so we need to update the gemspec to allow for the corresponding version of ActiveSupport. I am bumping to `7` so that I don't have to do this again too soon. If there is a breaking change in a `6.x` version we can update the gemspec again then.

This PR also updates the `.github/workflows/ruby.yml` so that the action to run the test suite automatically runs again.

Once this PR is merged I will bump the version to `1.0.2` and push a corresponding tag.