### PR TITLE
rollback ruby version to same ruby version used by ppsuite

### DIFF
--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7.8"
+  spec.required_ruby_version = ">= 2.7.7"
 
   spec.add_dependency "activesupport", ">= 4.0", "< 7.1"
   spec.add_dependency "awesome_print"

--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # bump me
   spec.required_ruby_version = ">= 2.7.7"
 
   spec.add_dependency "activesupport", ">= 4.0", "< 7.1"

--- a/jsonapi-matchers.gemspec
+++ b/jsonapi-matchers.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # bump me
   spec.required_ruby_version = ">= 2.7.7"
 
   spec.add_dependency "activesupport", ">= 4.0", "< 7.1"


### PR DESCRIPTION
Getting errors using the latest version of this library when I `bundle install` in PPsuite because it's on 2.7.7 and this library requires 2.7.8